### PR TITLE
fix: YAML.load being run on incorrect string

### DIFF
--- a/lib/cap-ec2/utils.rb
+++ b/lib/cap-ec2/utils.rb
@@ -2,7 +2,6 @@ require 'aws-sdk'
 
 module CapEC2
   module Utils
-
     module Server
       def ec2_tags
         id = self.properties.fetch(:aws_instance_id)
@@ -56,7 +55,7 @@ module CapEC2
 
       config_location = File.expand_path(fetch(:ec2_config), Dir.pwd) if fetch(:ec2_config)
       if config_location && File.exists?(config_location)
-        config = YAML.load(ERB.new(File.read(fetch(:ec2_config))))
+        config = YAML.load(ERB.new(File.read(fetch(:ec2_config))).result)
         if config
           set :ec2_project_tag, config['project_tag'] if config['project_tag']
           set :ec2_roles_tag, config['roles_tag'] if config['roles_tag']


### PR DESCRIPTION
Upstream PR: https://github.com/forward3d/cap-ec2/pull/81